### PR TITLE
1.3.5

### DIFF
--- a/python/simulator/simulator.py
+++ b/python/simulator/simulator.py
@@ -181,9 +181,16 @@ def main():
     """used to start the simulator"""
     global list_of_dir  # pylint: disable=global-statement
 
+    import sys
     from threading import Event
 
     from display import DisplayMock
+
+    def log_exception_handler(exctype, value, tb):
+        import traceback
+
+        logging.exception(''.join(traceback.format_exception(exctype, value, tb)))
+        sys.__excepthook__(exctype, value, tb)  # calls default excepthook
 
     logging.config.fileConfig(
         fname=config.work_dir + '/log.conf',
@@ -195,6 +202,7 @@ def main():
     log = logging.getLogger('werkzeug')
     log.setLevel(logging.ERROR)
 
+    sys.excepthook = log_exception_handler
     logging.info('####################################################################')
     logging.info('## Simulator loading ...                                          ##')
     logging.info('####################################################################')

--- a/python/src/custom2012pil.py
+++ b/python/src/custom2012pil.py
@@ -140,7 +140,7 @@ class Custom2012PILBoard(CustomBoard):
                     find_tiles(coord2, hsv_table, rgb_table, visited, candidates)
                 else:
                     logging.debug(
-                        f"{chr(ord('A') + coord[1])}{coord[0]+1} - remove {chr(ord('A') + coord2[1])}{coord2[0]+1}"
+                        f"{chr(ord('A') + coord[1])}{coord[0]+1} - remove {chr(ord('A') + coord2[1])}{coord2[0]+1} "
                         f"dist={distance((h1, s1, v1), (h2, s2, v2))} {(r, g, b)=}"
                     )
 

--- a/python/src/scrabble.py
+++ b/python/src/scrabble.py
@@ -572,24 +572,26 @@ class Game:
 
         move = copy.deepcopy(last_move)
         move.type = MoveType.LAST_RACK_BONUS if points[0] > 0 else MoveType.LAST_RACK_MALUS
+        move.time = str(datetime.datetime.now())
         move.player = 0
         move.word = rack_str
         move.removed_tiles = {}
         move.new_tiles = {}
         move.points = points[0]
         move.score = (move.score[0] + points[0], move.score[1] + points[1])
+        move.move = len(self.moves) + 1  # set move number
         self.moves.append(move)
-        move.move = len(self.moves)  # set move number
 
         move = copy.deepcopy(last_move)
         move.type = MoveType.LAST_RACK_MALUS if points[0] > 0 else MoveType.LAST_RACK_BONUS
+        move.time = str(datetime.datetime.now())
         move.player = 1
         move.word = rack_str
         move.removed_tiles = {}
         move.new_tiles = {}
         move.points = points[1]
         move.score = (move.score[0] + points[0], move.score[1] + points[1])
+        move.move = len(self.moves) + 1  # set move number
         self.moves.append(move)
-        move.move = len(self.moves)  # set move number
 
         return self

--- a/python/src/scrabscrap.py
+++ b/python/src/scrabscrap.py
@@ -46,6 +46,12 @@ logging.config.fileConfig(
 def main() -> None:
     """entry point for scrabscrap"""
 
+    def log_exception_handler(exctype, value, tb):
+        import traceback
+
+        logging.exception(''.join(traceback.format_exception(exctype, value, tb)))
+        sys.__excepthook__(exctype, value, tb)  # calls default excepthook
+
     def _cleanup():
         atexit.unregister(_cleanup)
         logging.debug('main-_atexit')
@@ -66,6 +72,7 @@ def main() -> None:
             os.system('sudo shutdown now')
         sys.exit(0)
 
+    sys.excepthook = log_exception_handler
     logging.info('####################################################################')
     logging.info('## ScrabScrap loading ...                                         ##')
     logging.info('####################################################################')

--- a/python/src/templates/simulator.html
+++ b/python/src/templates/simulator.html
@@ -108,7 +108,7 @@
                     <div class="py-2">
                         <div class="card">
                             <div class="card-header">
-                                {{ current_file }}
+                                {{ current_file }}&nbsp;
                             </div>
                             <div class="card-body">
                                 {% if img_current %}


### PR DESCRIPTION
Fixes
* set timestamp on last two moves (tiles on rack)
* custom2012pil: fix logging output
* simulator: display current filename
 
Features
* add excepthook to handle all uncaught exceptions

Upgrades

**Full Changelog**: https://github.com/scrabscrap/scrabble-scraper-v2/compare/v1.3.4...v1.3.5